### PR TITLE
Update faster-smarter-playbook.md

### DIFF
--- a/knpu/faster-smarter-playbook.md
+++ b/knpu/faster-smarter-playbook.md
@@ -100,6 +100,9 @@ in `changed_when`. Then, all we need to do is search for `You are already using 
 If that shows up in the command, then we know nothing changed. Paste that into the
 `search` filter.
 
+**TIP**
+In new versions, you can change the `result|search` filter wich is deprecated by : `result is search`.
+
 Test it out!
 
 ```terminal


### PR DESCRIPTION
Hello, 

Can you update with a tip this part : 
- name: Make sure Composer is as its latest version
    composer: 
      working_dir: "{{ symfony_root_dir }}"
      command: self-update
    when: composer_stat.stat.exists
    register: composer_self_update
    changed_when: "not composer_self_update.stdout|search('You are already using composer version')"
    tags: 
    - deploy

The output show us this : 
[DEPRECATION WARNING]: Using tests as filters is deprecated. Instead of using
`result|search` use `result is search`. This feature will be removed in version 2.9.
Deprecation warnings can be disabled by setting deprecation_warnings=False in
ansible.cfg.

You can replace by this : 
- name: Make sure Composer is as its latest version
    composer: 
      working_dir: "{{ symfony_root_dir }}"
      command: self-update
    when: composer_stat.stat.exists
    register: composer_self_update
    changed_when: "not composer_self_update.stdout is search('You are already using composer version')"
    tags: 
    - deploy

Cheers