### PR TITLE
Fixed missing hautelook/alice-bundle repo bundle by replacing with fork

### DIFF
--- a/composer.json
+++ b/composer.json
@@ -2,6 +2,12 @@
     "name": "victor/moo",
     "license": "proprietary",
     "type": "project",
+    "repositories": [
+        {
+            "type": "vcs",
+            "url": "https://github.com/theofidry/AliceBundle"
+        }
+    ],
     "autoload": {
         "psr-4": {
             "": "src/"

--- a/composer.lock
+++ b/composer.lock
@@ -4,7 +4,7 @@
         "Read more about it at https://getcomposer.org/doc/01-basic-usage.md#installing-dependencies",
         "This file is @generated automatically"
     ],
-    "content-hash": "8538baf975fe14b59bf94a2bddf950e5",
+    "content-hash": "fc4e07d8e51dccad3d3ef240bcfce552",
     "packages": [
         {
             "name": "composer/package-versions-deprecated",
@@ -2859,12 +2859,12 @@
             "version": "v1.4.1",
             "source": {
                 "type": "git",
-                "url": "https://github.com/hautelook/AliceBundle.git",
+                "url": "https://github.com/theofidry/AliceBundle.git",
                 "reference": "058925945bccbc8776725fec9e8557aca9666d9c"
             },
             "dist": {
                 "type": "zip",
-                "url": "https://api.github.com/repos/hautelook/AliceBundle/zipball/058925945bccbc8776725fec9e8557aca9666d9c",
+                "url": "https://api.github.com/repos/theofidry/AliceBundle/zipball/058925945bccbc8776725fec9e8557aca9666d9c",
                 "reference": "058925945bccbc8776725fec9e8557aca9666d9c",
                 "shasum": ""
             },
@@ -2908,7 +2908,11 @@
                     "Hautelook\\AliceBundle\\": "src"
                 }
             },
-            "notification-url": "https://packagist.org/downloads/",
+            "autoload-dev": {
+                "psr-4": {
+                    "Hautelook\\AliceBundle\\Tests\\": "tests"
+                }
+            },
             "license": [
                 "MIT"
             ],
@@ -2925,12 +2929,16 @@
             ],
             "description": "Symfony2 Bundle to manage fixtures with Alice and Faker.",
             "keywords": [
+                "Alice",
+                "Faker",
                 "Fixture",
-                "alice",
-                "faker",
-                "orm",
-                "symfony"
+                "ORM",
+                "Symfony"
             ],
+            "support": {
+                "source": "https://github.com/theofidry/AliceBundle/tree/v1.4.1",
+                "issues": "https://github.com/theofidry/AliceBundle/issues"
+            },
             "time": "2016-11-04T08:48:00+00:00"
         },
         {
@@ -3112,5 +3120,5 @@
     "platform-overrides": {
         "php": "7.1.0"
     },
-    "plugin-api-version": "2.0.0"
+    "plugin-api-version": "2.1.0"
 }


### PR DESCRIPTION
Fixed missing `hautelook/alice-bundle` repo bundle by replacing it with a fork
See: https://github.com/nelmio/alice/issues/1089